### PR TITLE
Add Tasks page

### DIFF
--- a/next/_templates/page/new/login.tsx.t
+++ b/next/_templates/page/new/login.tsx.t
@@ -1,0 +1,22 @@
+---
+to: "<%= pageType === 'login' ? `pages/${url}.tsx` : null %>"
+---
+
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import { DefaultLayout } from '~/components/layouts/DefaultLayout';
+import { makeRequireLoginProps } from '~/lib/utils/makeGetServerSideProps';
+
+export const getServerSideProps = makeRequireLoginProps();
+
+const Page: NextPage = () => {
+  return (
+    <DefaultLayout>
+      <Head>
+        <title>Virty</title>
+      </Head>
+    </DefaultLayout>
+  );
+};
+
+export default Page;

--- a/next/_templates/page/new/logout.tsx.t
+++ b/next/_templates/page/new/logout.tsx.t
@@ -1,0 +1,22 @@
+---
+to: "<%= pageType === 'logout' ? `pages/${url}.tsx` : null %>"
+---
+
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import { NoAuthLayout } from '~/components/layouts/NoAuthLayout';
+import { makeRequireLogoutProps } from '~/lib/utils/makeGetServerSideProps';
+
+export const getServerSideProps = makeRequireLogoutProps();
+
+const Page: NextPage = () => {
+  return (
+    <NoAuthLayout>
+      <Head>
+        <title>Virty</title>
+      </Head>
+    </NoAuthLayout>
+  );
+};
+
+export default Page;

--- a/next/_templates/page/new/prompt.js
+++ b/next/_templates/page/new/prompt.js
@@ -1,0 +1,15 @@
+module.exports = [
+  {
+    type: 'input',
+    name: 'url',
+    message: 'What is the URL of the page? (e.g. users/[id])',
+    required: true,
+  },
+  {
+    type: 'select',
+    name: 'pageType',
+    message: 'What type of page is this?',
+    choices: ['login', 'logout', 'simple'],
+    initial: 'login',
+  },
+];

--- a/next/_templates/page/new/simple.tsx.t
+++ b/next/_templates/page/new/simple.tsx.t
@@ -1,0 +1,18 @@
+---
+to: "<%= pageType === 'simple' ? `pages/${url}.tsx` : null %>"
+---
+
+import type { NextPage } from 'next';
+import Head from 'next/head';
+
+const Page: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Virty</title>
+      </Head>
+    </>
+  );
+};
+
+export default Page;

--- a/next/components/VMStatusController/index.tsx
+++ b/next/components/VMStatusController/index.tsx
@@ -1,27 +1,68 @@
-import { PowerStandby } from 'mdi-material-ui';
-import { FC } from 'react';
+import { Box, Grid, IconButton, Tooltip } from '@mui/material';
+import { AlertOutline, DeleteForever, DotsVertical, PowerStandby, ServerRemove, Wrench } from 'mdi-material-ui';
+import { FC, memo } from 'react';
+
+const VM_STATUS = {
+  POWER_ON: 1,
+  POWER_OFF: 5,
+  MAINTENANCE_MODE: 7,
+  DELETED_DOMAIN: 10,
+  LOST_NODE: 20,
+};
 
 type Props = {
   statusCode: number;
 };
 
-export const VMStatusController: FC<Props> = ({ statusCode }) => {
-  return <PowerStandby color={getStatusColor(statusCode)} sx={{ display: 'block' }} />;
-};
+export const VMStatusController: FC<Props> = memo(function NotMemoVMStatusController({ statusCode }) {
+  return (
+    <Grid container alignItems="center">
+      <Tooltip
+        title={
+          statusCode === VM_STATUS.POWER_ON
+            ? 'Power ON'
+            : statusCode === VM_STATUS.POWER_OFF
+            ? 'Power OFF'
+            : statusCode === VM_STATUS.MAINTENANCE_MODE
+            ? 'Maintenance mode'
+            : statusCode === VM_STATUS.DELETED_DOMAIN
+            ? 'Deleted domain'
+            : statusCode === VM_STATUS.LOST_NODE
+            ? 'Lost node'
+            : `Unknown status code: ${statusCode}`
+        }
+        placement="right"
+      >
+        <Box
+          sx={{
+            mr: 1,
+            '> *': {
+              display: 'block !important',
+            },
+          }}
+        >
+          <StatusIcon statusCode={statusCode} />
+        </Box>
+      </Tooltip>
+      <IconButton size="small">
+        <DotsVertical />
+      </IconButton>
+    </Grid>
+  );
+});
 
-const getStatusColor = (statusCode: number) => {
+const StatusIcon: FC<Props> = ({ statusCode }) => {
   switch (statusCode) {
-    case 1:
-      return 'primary';
-    case 5:
-      return 'disabled';
-    case 7:
-      return 'secondary';
-    case 10:
-      return 'error';
-    case 20:
-      return 'secondary';
-    default:
-      return 'warning';
+    case VM_STATUS.POWER_ON:
+      return <PowerStandby color="primary" />;
+    case VM_STATUS.POWER_OFF:
+      return <PowerStandby color="disabled" />;
+    case VM_STATUS.MAINTENANCE_MODE:
+      return <Wrench color="secondary" />;
+    case VM_STATUS.DELETED_DOMAIN:
+      return <DeleteForever color="error" />;
+    case VM_STATUS.LOST_NODE:
+      return <ServerRemove color="secondary" />;
   }
+  return <AlertOutline color="warning" />;
 };

--- a/next/components/VMStatusController/index.tsx
+++ b/next/components/VMStatusController/index.tsx
@@ -1,14 +1,7 @@
 import { Box, Grid, IconButton, Tooltip } from '@mui/material';
 import { AlertOutline, DeleteForever, DotsVertical, PowerStandby, ServerRemove, Wrench } from 'mdi-material-ui';
 import { FC, memo } from 'react';
-
-const VM_STATUS = {
-  POWER_ON: 1,
-  POWER_OFF: 5,
-  MAINTENANCE_MODE: 7,
-  DELETED_DOMAIN: 10,
-  LOST_NODE: 20,
-};
+import { VM_STATUS } from '~/lib/api/vm';
 
 type Props = {
   statusCode: number;

--- a/next/components/dialogs/AddVMDialog.tsx
+++ b/next/components/dialogs/AddVMDialog.tsx
@@ -1,5 +1,3 @@
-import { LoadingButton } from '@mui/lab';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Grid } from '@mui/material';
 import { JTDDataType } from 'ajv/dist/core';
 import { FC, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -8,6 +6,7 @@ import { generateProperty } from '~/lib/jtd';
 import { useConfirmDialog } from '~/store/confirmDialogState';
 import { useChoicesFetchers } from '~/store/formState';
 import { JtdForm } from '../JtdForm';
+import { BaseDialog } from './BaseDialog';
 
 type Props = {
   open: boolean;
@@ -140,30 +139,20 @@ export const AddVMDialog: FC<Props> = ({ open, onClose }) => {
   };
 
   return (
-    <Dialog maxWidth="sm" fullWidth open={open} onClose={!isDirty ? onClose : undefined}>
-      <DialogTitle>
-        <Grid container justifyContent="space-between" alignItems="center">
-          <Grid item>Add VM</Grid>
-        </Grid>
-      </DialogTitle>
-      <DialogContent sx={{ px: 1, pb: 0 }}>
-        <FormProvider {...formMethods}>
-          <JtdForm rootJtd={addVMFormJtd} isEditing />
-        </FormProvider>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <LoadingButton
-          onClick={handleSubmit(handleAddVM)}
-          variant="contained"
-          disableElevation
-          disabled={!isValid}
-          loading={isSubmitting}
-        >
-          Submit
-        </LoadingButton>
-      </DialogActions>
-    </Dialog>
+    <BaseDialog
+      title="Add VM"
+      open={open}
+      submitDisabled={!isValid}
+      submitLoading={isSubmitting}
+      persistent={isDirty}
+      disabledPadding
+      onClose={onClose}
+      onSubmit={handleSubmit(handleAddVM)}
+    >
+      <FormProvider {...formMethods}>
+        <JtdForm rootJtd={addVMFormJtd} isEditing />
+      </FormProvider>
+    </BaseDialog>
   );
 };
 

--- a/next/components/dialogs/BaseDialog.tsx
+++ b/next/components/dialogs/BaseDialog.tsx
@@ -3,7 +3,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { FC, PropsWithChildren, ReactNode } from 'react';
 import { LoadingButton } from '@mui/lab';
 
-export type Props = PropsWithChildren<{
+type Props = PropsWithChildren<{
   title: ReactNode;
   submitText?: string;
   open: boolean;
@@ -12,6 +12,7 @@ export type Props = PropsWithChildren<{
   submitLoading?: boolean;
   maxWidth?: Breakpoint;
   persistent?: boolean;
+  disabledPadding?: boolean;
   onClose: () => void;
   onSubmit?: () => void;
   onDelete?: () => void;
@@ -26,6 +27,7 @@ export const BaseDialog: FC<Props> = ({
   submitLoading,
   maxWidth = 'xs',
   persistent = false,
+  disabledPadding = false,
   onClose,
   onSubmit,
   onDelete,
@@ -45,7 +47,7 @@ export const BaseDialog: FC<Props> = ({
           )}
         </Grid>
       </DialogTitle>
-      <DialogContent sx={{ pt: '10px !important' }}>{children}</DialogContent>
+      <DialogContent sx={{ pt: '10px !important', p: disabledPadding ? 0 : undefined }}>{children}</DialogContent>
       {onSubmit && (
         <DialogActions>
           <Button onClick={onClose}>Cancel</Button>

--- a/next/components/dialogs/TaskDetailsDialog/index.tsx
+++ b/next/components/dialogs/TaskDetailsDialog/index.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+import { BaseTable } from '~/components/tables/BaseTable';
+import { TaskSelect } from '~/lib/api/generated';
+import { BaseDialog } from '../BaseDialog';
+
+type Props = {
+  open: boolean;
+  task?: TaskSelect;
+  onClose: () => void;
+};
+
+export const TaskDetailsDialog: FC<Props> = ({ open, task, onClose }) => {
+  if (!task) {
+    return null;
+  }
+
+  return (
+    <BaseDialog title="Task Details" maxWidth="md" open={open} onClose={onClose}>
+      <BaseTable
+        cols={[
+          { name: 'Label', getItem: (item) => item.label },
+          { name: 'Value', getItem: (item) => item.value },
+        ]}
+        items={[
+          { label: 'UUID', value: task.uuid },
+          { label: 'Message', value: task.message },
+          { label: 'Request', value: <pre>{JSON.stringify(task.request, null, 2)}</pre> },
+        ]}
+        hiddenHeader
+        disableElevation
+      />
+    </BaseDialog>
+  );
+};

--- a/next/components/layouts/NavigationDrawer.tsx
+++ b/next/components/layouts/NavigationDrawer.tsx
@@ -15,7 +15,7 @@ import {
   Toolbar,
   useTheme,
 } from '@mui/material';
-import { Home, CubeOutline } from 'mdi-material-ui';
+import { Home, CubeOutline, CheckboxMultipleMarkedOutline } from 'mdi-material-ui';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { FC, useEffect, useState } from 'react';
@@ -33,6 +33,11 @@ const drawerRoutes = [
     title: 'VM',
     path: '/vm',
     icon: <CubeOutline />,
+  },
+  {
+    title: 'Task',
+    path: '/task',
+    icon: <CheckboxMultipleMarkedOutline />,
   },
 ];
 

--- a/next/components/layouts/NavigationDrawer.tsx
+++ b/next/components/layouts/NavigationDrawer.tsx
@@ -1,7 +1,6 @@
 import {
-  Card,
-  CardContent,
-  CardHeader,
+  Box,
+  Divider,
   Drawer,
   FormControl,
   InputLabel,
@@ -13,12 +12,14 @@ import {
   MenuItem,
   Select,
   Toolbar,
+  Typography,
   useTheme,
 } from '@mui/material';
 import { Home, CubeOutline, CheckboxMultipleMarkedOutline } from 'mdi-material-ui';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { FC, useEffect, useState } from 'react';
+import { SCOPE_TO_LABEL } from '~/lib/api/auth';
 import { useDrawer } from '~/store/drawerState';
 import { useAuth } from '~/store/userState';
 
@@ -44,7 +45,7 @@ const drawerRoutes = [
 export const NavigationDrawer: FC = () => {
   const theme = useTheme();
   const { drawer } = useDrawer();
-  const { user } = useAuth();
+  const { user, changeScope } = useAuth();
   const router = useRouter();
   const [currentPath, setCurrentPath] = useState(router.pathname);
 
@@ -76,26 +77,28 @@ export const NavigationDrawer: FC = () => {
       }}
     >
       <Toolbar />
-      <Card>
-        <CardHeader title={user?.username} />
-        <CardContent>
-          <FormControl fullWidth>
-            <InputLabel id="scope-select-label">Scope</InputLabel>
-            <Select
-              labelId="scope-select-label"
-              value={'admin'}
-              label="Scope"
-              // onChange={handleChange}
-            >
-              {user?.scopes.map((scope, i) => (
-                <MenuItem key={i} value={scope}>
-                  {scope}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </CardContent>
-      </Card>
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          {user?.username}
+        </Typography>
+        <FormControl fullWidth>
+          <InputLabel id="scope-select-label">Scope</InputLabel>
+          <Select
+            labelId="scope-select-label"
+            value={user?.scopeIndex}
+            label="Scope"
+            disabled={user?.scopes.length === 1}
+            onChange={(e) => changeScope(e.target.value as number)}
+          >
+            {user?.scopes.map((scope, i) => (
+              <MenuItem key={i} value={i}>
+                {SCOPE_TO_LABEL[scope] || scope}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Divider />
       <List>
         {drawerRoutes.map((route, i) => (
           <ListItem

--- a/next/components/layouts/NoAuthLayout.tsx
+++ b/next/components/layouts/NoAuthLayout.tsx
@@ -1,9 +1,9 @@
 import { FC, PropsWithChildren } from 'react';
 import { Container, Typography } from '@mui/material';
 
-export type NoAuthLayoutProps = PropsWithChildren<{}>;
+type Props = PropsWithChildren<{}>;
 
-export const NoAuthLayout: FC<NoAuthLayoutProps> = ({ children }) => {
+export const NoAuthLayout: FC<Props> = ({ children }) => {
   return (
     <Container sx={{ width: 'fit-content' }}>
       <Typography variant="h2" align="center" mt={15} mb={5}>

--- a/next/components/tables/TasksTable/index.tsx
+++ b/next/components/tables/TasksTable/index.tsx
@@ -7,13 +7,13 @@ import useSWR from 'swr';
 import { formatDate } from '~/lib/utils/date';
 import { CubeOutline, Database, HelpRhombus, Server, Wan } from 'mdi-material-ui';
 import { TASK_METHOD, TASK_RESOURCE } from '~/lib/api/task';
-
-const IS_ADMIN = true;
+import { useAuth } from '~/store/userState';
 
 export const TasksTable: FC = () => {
+  const { user } = useAuth();
   const { enqueueNotistack } = useNotistack();
   const { data, error, isValidating } = useSWR(
-    ['tasksApi.getTasksApiTasksGet', IS_ADMIN],
+    ['tasksApi.getTasksApiTasksGet', user?.isAdminMode],
     ([, isAdmin]) => tasksApi.getTasksApiTasksGet(isAdmin).then((res) => res.data),
     { revalidateOnFocus: false }
   );

--- a/next/components/tables/TasksTable/index.tsx
+++ b/next/components/tables/TasksTable/index.tsx
@@ -15,8 +15,8 @@ export const TasksTable: FC = () => {
   const { user } = useAuth();
   const { enqueueNotistack } = useNotistack();
   const { data, error, isValidating } = useSWR(
-    ['tasksApi.getTasksApiTasksGet', user?.isAdminMode],
-    ([, isAdmin]) => tasksApi.getTasksApiTasksGet(isAdmin).then((res) => res.data),
+    ['tasksApi.getTasksApiTasksGet', user],
+    ([, user]) => tasksApi.getTasksApiTasksGet(user?.isAdminMode).then((res) => res.data),
     { revalidateOnFocus: false }
   );
   const [selectedTask, setSelectedTask] = useState<TaskSelect | undefined>(undefined);

--- a/next/components/tables/TasksTable/index.tsx
+++ b/next/components/tables/TasksTable/index.tsx
@@ -1,12 +1,12 @@
-import { Box, Typography } from '@mui/material';
+import { Box, IconButton, Typography } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import { FC } from 'react';
 import { useNotistack } from '~/lib/utils/notistack';
 import { tasksApi } from '~/lib/api';
 import useSWR from 'swr';
 import { formatDate } from '~/lib/utils/date';
-import { CubeOutline, Database, HelpRhombus, Server, Wan } from 'mdi-material-ui';
-import { TASK_METHOD, TASK_RESOURCE } from '~/lib/api/task';
+import { CheckCircle, CubeOutline, Database, DotsVertical, HelpRhombus, Server, Wan } from 'mdi-material-ui';
+import { TASK_METHOD, TASK_RESOURCE, TASK_STATUS } from '~/lib/api/task';
 import { useAuth } from '~/store/userState';
 
 export const TasksTable: FC = () => {
@@ -33,7 +33,20 @@ export const TasksTable: FC = () => {
         loading={!data || isValidating}
         error={!!error || undefined}
         columns={[
-          { headerName: 'Status', field: 'status', disableColumnMenu: true, flex: 1 },
+          {
+            headerName: 'Status',
+            field: 'status',
+            disableColumnMenu: true,
+            flex: 1,
+            renderCell: (params) => (
+              <>
+                <StatusIcon status={params.value} />
+                <Typography variant="body2" sx={{ ml: 1 }}>
+                  {params.value}
+                </Typography>
+              </>
+            ),
+          },
           { headerName: 'UUID', field: 'uuid', disableColumnMenu: true, flex: 2 },
           {
             headerName: 'Request',
@@ -67,10 +80,39 @@ export const TasksTable: FC = () => {
             flex: 1,
             renderCell: (params) => `${Math.round(params.row.runTime! * 100) / 100} s`,
           },
+          {
+            headerName: '',
+            field: 'details',
+            disableColumnMenu: true,
+            sortable: false,
+            width: 40,
+            align: 'center',
+            renderCell: (params) => (
+              <IconButton>
+                <DotsVertical />
+              </IconButton>
+            ),
+          },
         ]}
       />
     </Box>
   );
+};
+
+type StatusIconProps = {
+  status: string;
+};
+
+const StatusIcon: FC<StatusIconProps> = ({ status }) => {
+  const color =
+    status === TASK_STATUS.FINISH
+      ? 'primary.main'
+      : status === TASK_STATUS.INIT
+      ? 'grey.500'
+      : status === TASK_STATUS.ERROR
+      ? 'error.main'
+      : 'warning.main';
+  return <CheckCircle sx={{ color }} />;
 };
 
 type ResourceIconProps = {

--- a/next/components/tables/TasksTable/index.tsx
+++ b/next/components/tables/TasksTable/index.tsx
@@ -6,6 +6,7 @@ import { tasksApi } from '~/lib/api';
 import useSWR from 'swr';
 import { formatDate } from '~/lib/utils/date';
 import { CubeOutline, Database, HelpRhombus, Server, Wan } from 'mdi-material-ui';
+import { TASK_METHOD, TASK_RESOURCE } from '~/lib/api/task';
 
 const IS_ADMIN = true;
 
@@ -97,17 +98,4 @@ const ResourceIcon: FC<ResourceIconProps> = ({ method, resource }) => {
       return <Wan color={color} />;
   }
   return <HelpRhombus color={color} />;
-};
-
-const TASK_METHOD = {
-  POST: 'post',
-  PUT: 'put',
-  DELETE: 'delete',
-};
-
-const TASK_RESOURCE = {
-  VM: 'vm',
-  NODE: 'node',
-  STORAGE: 'storage',
-  NETWORK: 'network',
 };

--- a/next/components/tables/TasksTable/index.tsx
+++ b/next/components/tables/TasksTable/index.tsx
@@ -1,0 +1,113 @@
+import { Box, Typography } from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
+import { FC } from 'react';
+import { useNotistack } from '~/lib/utils/notistack';
+import { tasksApi } from '~/lib/api';
+import useSWR from 'swr';
+import { formatDate } from '~/lib/utils/date';
+import { CubeOutline, Database, HelpRhombus, Server, Wan } from 'mdi-material-ui';
+
+const IS_ADMIN = true;
+
+export const TasksTable: FC = () => {
+  const { enqueueNotistack } = useNotistack();
+  const { data, error, isValidating } = useSWR(
+    ['tasksApi.getTasksApiTasksGet', IS_ADMIN],
+    ([, isAdmin]) => tasksApi.getTasksApiTasksGet(isAdmin).then((res) => res.data),
+    { revalidateOnFocus: false }
+  );
+
+  if (error) {
+    enqueueNotistack('Failed to fetch tasks.', { variant: 'error' });
+  }
+
+  return (
+    <Box component="div" sx={{ height: '100%' }}>
+      <DataGrid
+        disableSelectionOnClick
+        rowHeight={40}
+        pageSize={25}
+        getRowId={(row) => row.uuid!}
+        rows={data || []}
+        loading={!data || isValidating}
+        error={!!error || undefined}
+        columns={[
+          { headerName: 'Status', field: 'status', disableColumnMenu: true, flex: 1 },
+          { headerName: 'UUID', field: 'uuid', disableColumnMenu: true, flex: 2 },
+          {
+            headerName: 'Request',
+            field: 'request',
+            disableColumnMenu: true,
+            flex: 1,
+            minWidth: 150,
+            valueGetter: (params) => `${params.row.method}.${params.row.resource}.${params.row.object}`,
+            renderCell: (params) => (
+              <>
+                <ResourceIcon method={params.row.method!} resource={params.row.resource!} />
+                <Typography variant="body2" sx={{ ml: 1 }}>
+                  {params.value}
+                </Typography>
+              </>
+            ),
+          },
+          { headerName: 'User', field: 'userId', disableColumnMenu: true, flex: 1 },
+          {
+            headerName: 'PostTime',
+            field: 'postTime',
+            disableColumnMenu: true,
+            flex: 1,
+            minWidth: 160,
+            renderCell: (params) => formatDate(params.row.postTime!),
+          },
+          {
+            headerName: 'TunTime',
+            field: 'runTime',
+            disableColumnMenu: true,
+            flex: 1,
+            renderCell: (params) => `${Math.round(params.row.runTime! * 100) / 100} s`,
+          },
+        ]}
+      />
+    </Box>
+  );
+};
+
+type ResourceIconProps = {
+  method: string;
+  resource: string;
+};
+
+const ResourceIcon: FC<ResourceIconProps> = ({ method, resource }) => {
+  const color =
+    method === TASK_METHOD.POST
+      ? 'success'
+      : method === TASK_METHOD.PUT
+      ? 'primary'
+      : method === TASK_METHOD.DELETE
+      ? 'error'
+      : 'warning';
+  switch (resource) {
+    case TASK_RESOURCE.VM:
+      return <CubeOutline color={color} />;
+    case TASK_RESOURCE.NODE:
+      return <Server color={color} />;
+    case TASK_RESOURCE.STORAGE:
+      return <Database color={color} />;
+    case TASK_RESOURCE.NETWORK:
+      return <Wan color={color} />;
+  }
+  return <HelpRhombus color={color} />;
+};
+
+const TASK_METHOD = {
+  POST: 'post',
+  PUT: 'put',
+  DELETE: 'delete',
+};
+
+const TASK_RESOURCE = {
+  VM: 'vm',
+  NODE: 'node',
+  STORAGE: 'storage',
+  NETWORK: 'network',
+};

--- a/next/components/tables/TasksTable/index.tsx
+++ b/next/components/tables/TasksTable/index.tsx
@@ -1,6 +1,6 @@
 import { Box, IconButton, Typography } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { useNotistack } from '~/lib/utils/notistack';
 import { tasksApi } from '~/lib/api';
 import useSWR from 'swr';
@@ -8,6 +8,8 @@ import { formatDate } from '~/lib/utils/date';
 import { CheckCircle, CubeOutline, Database, DotsVertical, HelpRhombus, Server, Wan } from 'mdi-material-ui';
 import { TASK_METHOD, TASK_RESOURCE, TASK_STATUS } from '~/lib/api/task';
 import { useAuth } from '~/store/userState';
+import { TaskSelect } from '~/lib/api/generated';
+import { TaskDetailsDialog } from '~/components/dialogs/TaskDetailsDialog';
 
 export const TasksTable: FC = () => {
   const { user } = useAuth();
@@ -17,85 +19,90 @@ export const TasksTable: FC = () => {
     ([, isAdmin]) => tasksApi.getTasksApiTasksGet(isAdmin).then((res) => res.data),
     { revalidateOnFocus: false }
   );
+  const [selectedTask, setSelectedTask] = useState<TaskSelect | undefined>(undefined);
 
   if (error) {
     enqueueNotistack('Failed to fetch tasks.', { variant: 'error' });
   }
 
   return (
-    <Box component="div" sx={{ height: '100%' }}>
-      <DataGrid
-        disableSelectionOnClick
-        rowHeight={40}
-        pageSize={25}
-        getRowId={(row) => row.uuid!}
-        rows={data || []}
-        loading={!data || isValidating}
-        error={!!error || undefined}
-        columns={[
-          {
-            headerName: 'Status',
-            field: 'status',
-            disableColumnMenu: true,
-            flex: 1,
-            renderCell: (params) => (
-              <>
-                <StatusIcon status={params.value} />
-                <Typography variant="body2" sx={{ ml: 1 }}>
-                  {params.value}
-                </Typography>
-              </>
-            ),
-          },
-          { headerName: 'UUID', field: 'uuid', disableColumnMenu: true, flex: 2 },
-          {
-            headerName: 'Request',
-            field: 'request',
-            disableColumnMenu: true,
-            flex: 1,
-            minWidth: 150,
-            valueGetter: (params) => `${params.row.method}.${params.row.resource}.${params.row.object}`,
-            renderCell: (params) => (
-              <>
-                <ResourceIcon method={params.row.method!} resource={params.row.resource!} />
-                <Typography variant="body2" sx={{ ml: 1 }}>
-                  {params.value}
-                </Typography>
-              </>
-            ),
-          },
-          { headerName: 'User', field: 'userId', disableColumnMenu: true, flex: 1 },
-          {
-            headerName: 'PostTime',
-            field: 'postTime',
-            disableColumnMenu: true,
-            flex: 1,
-            minWidth: 160,
-            renderCell: (params) => formatDate(params.row.postTime!),
-          },
-          {
-            headerName: 'TunTime',
-            field: 'runTime',
-            disableColumnMenu: true,
-            flex: 1,
-            renderCell: (params) => `${Math.round(params.row.runTime! * 100) / 100} s`,
-          },
-          {
-            headerName: '',
-            field: 'details',
-            disableColumnMenu: true,
-            sortable: false,
-            width: 40,
-            align: 'center',
-            renderCell: (params) => (
-              <IconButton>
-                <DotsVertical />
-              </IconButton>
-            ),
-          },
-        ]}
-      />
-    </Box>
+    <>
+      <Box component="div" sx={{ height: '100%' }}>
+        <DataGrid
+          disableSelectionOnClick
+          rowHeight={40}
+          pageSize={25}
+          getRowId={(row) => row.uuid!}
+          rows={data || []}
+          loading={!data || isValidating}
+          error={!!error || undefined}
+          columns={[
+            {
+              headerName: 'Status',
+              field: 'status',
+              disableColumnMenu: true,
+              flex: 1,
+              renderCell: (params) => (
+                <>
+                  <StatusIcon status={params.value} />
+                  <Typography variant="body2" sx={{ ml: 1 }}>
+                    {params.value}
+                  </Typography>
+                </>
+              ),
+            },
+            { headerName: 'UUID', field: 'uuid', disableColumnMenu: true, flex: 2 },
+            {
+              headerName: 'Request',
+              field: 'request',
+              disableColumnMenu: true,
+              flex: 1,
+              minWidth: 150,
+              valueGetter: (params) => `${params.row.method}.${params.row.resource}.${params.row.object}`,
+              renderCell: (params) => (
+                <>
+                  <ResourceIcon method={params.row.method!} resource={params.row.resource!} />
+                  <Typography variant="body2" sx={{ ml: 1 }}>
+                    {params.value}
+                  </Typography>
+                </>
+              ),
+            },
+            { headerName: 'User', field: 'userId', disableColumnMenu: true, flex: 1 },
+            {
+              headerName: 'PostTime',
+              field: 'postTime',
+              disableColumnMenu: true,
+              flex: 1,
+              minWidth: 160,
+              renderCell: (params) => formatDate(params.row.postTime!),
+            },
+            {
+              headerName: 'TunTime',
+              field: 'runTime',
+              disableColumnMenu: true,
+              flex: 1,
+              renderCell: (params) => `${Math.round(params.row.runTime! * 100) / 100} s`,
+            },
+            {
+              headerName: '',
+              field: 'details',
+              disableColumnMenu: true,
+              sortable: false,
+              width: 40,
+              align: 'center',
+              renderCell: (params) => (
+                <IconButton size="small" onClick={() => setSelectedTask(params.row)}>
+                  <DotsVertical />
+                </IconButton>
+              ),
+            },
+          ]}
+        />
+      </Box>
+
+      <TaskDetailsDialog open={!!selectedTask} task={selectedTask} onClose={() => setSelectedTask(undefined)} />
+    </>
   );
 };
 

--- a/next/components/tables/VMTable.tsx
+++ b/next/components/tables/VMTable.tsx
@@ -7,13 +7,13 @@ import { Cpu64Bit, Memory } from 'mdi-material-ui';
 import NextLink from 'next/link';
 import useSWR from 'swr';
 import { VMStatusController } from '../VMStatusController';
-
-const IS_ADMIN = true;
+import { useAuth } from '~/store/userState';
 
 export const VMTable: FC = () => {
+  const { user } = useAuth();
   const { enqueueNotistack } = useNotistack();
   const { data, error, isValidating } = useSWR(
-    ['vmsApi.getApiDomainApiVmsGet', IS_ADMIN],
+    ['vmsApi.getApiDomainApiVmsGet', user?.isAdminMode],
     ([, isAdmin]) => vmsApi.getApiDomainApiVmsGet(isAdmin).then((res) => res.data),
     { revalidateOnFocus: false }
   );

--- a/next/components/tables/VMTable.tsx
+++ b/next/components/tables/VMTable.tsx
@@ -13,8 +13,8 @@ export const VMTable: FC = () => {
   const { user } = useAuth();
   const { enqueueNotistack } = useNotistack();
   const { data, error, isValidating } = useSWR(
-    ['vmsApi.getApiDomainApiVmsGet', user?.isAdminMode],
-    ([, isAdmin]) => vmsApi.getApiDomainApiVmsGet(isAdmin).then((res) => res.data),
+    ['vmsApi.getApiDomainApiVmsGet', user],
+    ([, user]) => vmsApi.getApiDomainApiVmsGet(user?.isAdminMode).then((res) => res.data),
     { revalidateOnFocus: false }
   );
 

--- a/next/components/tables/VMTable.tsx
+++ b/next/components/tables/VMTable.tsx
@@ -1,9 +1,9 @@
-import { Box, Link } from '@mui/material';
+import { Box, IconButton, Link, Typography } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import { FC } from 'react';
 import { useNotistack } from '~/lib/utils/notistack';
 import { vmsApi } from '~/lib/api';
-import { Cpu64Bit, Memory } from 'mdi-material-ui';
+import { DotsVertical } from 'mdi-material-ui';
 import NextLink from 'next/link';
 import useSWR from 'swr';
 import { VMStatusController } from '../VMStatusController';
@@ -38,13 +38,14 @@ export const VMTable: FC = () => {
             disableColumnMenu: true,
             renderCell: (params) => <VMStatusController statusCode={params.value} />,
           },
-          { headerName: 'Name', field: 'name', disableColumnMenu: true, flex: 1 },
-          { headerName: 'Node', field: 'nodeName', disableColumnMenu: true, flex: 1 },
+          { headerName: 'Name', field: 'name', disableColumnMenu: true, flex: 1, minWidth: 150 },
+          { headerName: 'Node', field: 'nodeName', disableColumnMenu: true, flex: 1, minWidth: 150 },
           {
             headerName: 'UUID',
             field: 'uuid',
             disableColumnMenu: true,
             flex: 2,
+            minWidth: 290,
             renderCell: (params) => (
               <NextLink href={`/vm/${params.value}`} passHref>
                 <Link>{params.value}</Link>
@@ -55,27 +56,54 @@ export const VMTable: FC = () => {
             headerName: 'RAM',
             field: 'memory',
             disableColumnMenu: true,
-            valueGetter: (params) => `${params.value / 1024} G`,
-            renderCell: (params) => (
-              <>
-                <Memory sx={{ mr: 1 }} />
-                {params.value}
-              </>
-            ),
+            align: 'right',
+            flex: 1,
+            minWidth: 80,
+            renderCell: (params) => `${params.value / 1024} GB`,
           },
           {
             headerName: 'CPU',
             field: 'core',
             disableColumnMenu: true,
+            align: 'right',
+            flex: 1,
+            minWidth: 80,
+            renderCell: (params) => `${params.value} Core`,
+          },
+          {
+            headerName: 'User',
+            field: 'ownerUserId',
+            disableColumnMenu: true,
+            flex: 1,
+            minWidth: 150,
             renderCell: (params) => (
               <>
-                <Cpu64Bit sx={{ mr: 1 }} />
-                {params.value}
+                <Typography variant="body2" sx={{ mr: 'auto' }}>
+                  {params.value}
+                </Typography>
+                <IconButton size="small">
+                  <DotsVertical />
+                </IconButton>
               </>
             ),
           },
-          { headerName: 'User', field: 'ownerUserId', disableColumnMenu: true },
-          { headerName: 'Group', field: 'ownerProject', disableColumnMenu: true },
+          {
+            headerName: 'Group',
+            field: 'ownerProject',
+            disableColumnMenu: true,
+            flex: 1,
+            minWidth: 150,
+            renderCell: (params) => (
+              <>
+                <Typography variant="body2" sx={{ mr: 'auto' }}>
+                  {params.value}
+                </Typography>
+                <IconButton size="small">
+                  <DotsVertical />
+                </IconButton>
+              </>
+            ),
+          },
         ]}
       />
     </Box>

--- a/next/components/utils/LoadingBox.tsx
+++ b/next/components/utils/LoadingBox.tsx
@@ -1,11 +1,11 @@
 import { Backdrop, CircularProgress, Grid } from '@mui/material';
 import { FC } from 'react';
 
-export type LoadingBoxProps = {
+type Props = {
   backdrop?: boolean;
 };
 
-export const LoadingBox: FC<LoadingBoxProps> = ({ backdrop }) => {
+export const LoadingBox: FC<Props> = ({ backdrop }) => {
   return backdrop ? (
     <Backdrop sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }} open={true}>
       <CircularProgress />

--- a/next/lib/api/auth.ts
+++ b/next/lib/api/auth.ts
@@ -1,0 +1,4 @@
+export const SCOPE_TO_LABEL = {
+  user: 'General User',
+  admin: 'Administrator',
+} as const;

--- a/next/lib/api/task.ts
+++ b/next/lib/api/task.ts
@@ -1,0 +1,12 @@
+export const TASK_METHOD = {
+  POST: 'post',
+  PUT: 'put',
+  DELETE: 'delete',
+} as const;
+
+export const TASK_RESOURCE = {
+  VM: 'vm',
+  NODE: 'node',
+  STORAGE: 'storage',
+  NETWORK: 'network',
+} as const;

--- a/next/lib/api/task.ts
+++ b/next/lib/api/task.ts
@@ -1,3 +1,9 @@
+export const TASK_STATUS = {
+  FINISH: 'finish',
+  INIT: 'init',
+  ERROR: 'error',
+} as const;
+
 export const TASK_METHOD = {
   POST: 'post',
   PUT: 'put',

--- a/next/lib/api/vm.ts
+++ b/next/lib/api/vm.ts
@@ -1,0 +1,7 @@
+export const VM_STATUS = {
+  POWER_ON: 1,
+  POWER_OFF: 5,
+  MAINTENANCE_MODE: 7,
+  DELETED_DOMAIN: 10,
+  LOST_NODE: 20,
+} as const;

--- a/next/lib/utils/date.ts
+++ b/next/lib/utils/date.ts
@@ -1,0 +1,3 @@
+import dayjs from 'dayjs';
+
+export const formatDate = (date: string) => dayjs(date).format('YYYY-MM-DD HH:mm:ss');

--- a/next/lib/utils/makeGetServerSideProps.ts
+++ b/next/lib/utils/makeGetServerSideProps.ts
@@ -1,5 +1,5 @@
 import { GetServerSideProps, GetServerSidePropsResult, PreviewData } from 'next';
-import { destroyCookie, parseCookies } from 'nookies';
+import nookies from 'nookies';
 import { ParsedUrlQuery } from 'querystring';
 import { authApi } from '../api';
 
@@ -8,7 +8,7 @@ export const makeRequireLoginProps =
     getServerSideProps?: GetServerSideProps<P, Q, D>
   ): GetServerSideProps<P, Q, D> =>
   async (ctx) => {
-    const { token } = parseCookies(ctx);
+    const { token } = nookies.get(ctx);
     const isValid = await authApi
       .readAuthValidateApiAuthValidateGet({
         headers: {
@@ -19,7 +19,7 @@ export const makeRequireLoginProps =
       .catch(() => false);
 
     if (!isValid) {
-      destroyCookie(ctx, 'token');
+      nookies.destroy(ctx, 'token', { path: '/' });
       return {
         redirect: {
           destination: '/login',
@@ -42,7 +42,7 @@ export const makeRequireLogoutProps =
     getServerSideProps?: GetServerSideProps<P, Q, D>
   ): GetServerSideProps<P, Q, D> =>
   async (ctx) => {
-    const { token } = parseCookies(ctx);
+    const { token } = nookies.get(ctx);
     const isValid = await authApi
       .readAuthValidateApiAuthValidateGet({
         headers: {
@@ -61,7 +61,7 @@ export const makeRequireLogoutProps =
       };
     }
 
-    destroyCookie(ctx, 'token');
+    nookies.destroy(ctx, 'token', { path: '/' });
     if (!getServerSideProps) {
       return {
         props: {},

--- a/next/package.json
+++ b/next/package.json
@@ -12,6 +12,7 @@
     "format:prettier": "prettier --write './**/*.{ts,tsx,css,html}'",
     "generate:api": "openapi-generator-cli generate -i ./openapi.json -g typescript-axios -o ./lib/api/generated",
     "generate:component": "hygen component new",
+    "generate:page": "hygen page new",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/next/package.json
+++ b/next/package.json
@@ -25,6 +25,7 @@
     "@mui/material": "^5.11.2",
     "@mui/x-data-grid": "^5.17.17",
     "ajv": "^8.11.2",
+    "dayjs": "^1.11.7",
     "mdi-material-ui": "^7.6.0",
     "next": "12.3.1",
     "nookies": "^2.5.2",

--- a/next/pages/logout.tsx
+++ b/next/pages/logout.tsx
@@ -1,0 +1,20 @@
+import type { NextPage } from 'next';
+import nookies from 'nookies';
+import { makeRequireLoginProps } from '~/lib/utils/makeGetServerSideProps';
+
+export const getServerSideProps = makeRequireLoginProps(async (ctx) => {
+  nookies.destroy(ctx, 'token', { path: '/' });
+
+  return {
+    redirect: {
+      destination: '/login',
+      permanent: false,
+    },
+  };
+});
+
+const Page: NextPage = () => {
+  return null;
+};
+
+export default Page;

--- a/next/pages/task.tsx
+++ b/next/pages/task.tsx
@@ -2,6 +2,7 @@ import { Grid, Typography } from '@mui/material';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { DefaultLayout } from '~/components/layouts/DefaultLayout';
+import { TasksTable } from '~/components/tables/TasksTable';
 import { makeRequireLoginProps } from '~/lib/utils/makeGetServerSideProps';
 
 export const getServerSideProps = makeRequireLoginProps();
@@ -18,6 +19,8 @@ const Page: NextPage = () => {
           <Typography variant="h4">Task</Typography>
         </Grid>
       </Grid>
+
+      <TasksTable />
     </DefaultLayout>
   );
 };

--- a/next/pages/task.tsx
+++ b/next/pages/task.tsx
@@ -1,13 +1,31 @@
-import { Grid, Typography } from '@mui/material';
+import { Button, Grid, Typography } from '@mui/material';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { DefaultLayout } from '~/components/layouts/DefaultLayout';
 import { TasksTable } from '~/components/tables/TasksTable';
 import { makeRequireLoginProps } from '~/lib/utils/makeGetServerSideProps';
+import { useConfirmDialog } from '~/store/confirmDialogState';
 
 export const getServerSideProps = makeRequireLoginProps();
 
 const Page: NextPage = () => {
+  const { openConfirmDialog } = useConfirmDialog();
+
+  const deleteAllTasks = async () => {
+    const confirmed = await openConfirmDialog({
+      title: 'Delete all tasks',
+      description:
+        'Are you sure you want to delete all tasks?\nThis operation deletes everything, including the running and finished portions. Tasks in progress may be executed incompletely.',
+      submitText: 'Delete',
+      color: 'error',
+    });
+    if (!confirmed) {
+      return;
+    }
+
+    console.log('delete all tasks');
+  };
+
   return (
     <DefaultLayout>
       <Head>
@@ -17,6 +35,11 @@ const Page: NextPage = () => {
       <Grid container alignItems="center" spacing={2} sx={{ mt: 0, mb: 1 }}>
         <Grid item>
           <Typography variant="h4">Task</Typography>
+        </Grid>
+        <Grid item>
+          <Button variant="contained" color="error" onClick={deleteAllTasks}>
+            Delete
+          </Button>
         </Grid>
       </Grid>
 

--- a/next/pages/task.tsx
+++ b/next/pages/task.tsx
@@ -1,0 +1,25 @@
+import { Grid, Typography } from '@mui/material';
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import { DefaultLayout } from '~/components/layouts/DefaultLayout';
+import { makeRequireLoginProps } from '~/lib/utils/makeGetServerSideProps';
+
+export const getServerSideProps = makeRequireLoginProps();
+
+const Page: NextPage = () => {
+  return (
+    <DefaultLayout>
+      <Head>
+        <title>Virty - Task</title>
+      </Head>
+
+      <Grid container alignItems="center" spacing={2} sx={{ mt: 0, mb: 1 }}>
+        <Grid item>
+          <Typography variant="h4">Task</Typography>
+        </Grid>
+      </Grid>
+    </DefaultLayout>
+  );
+};
+
+export default Page;

--- a/next/store/userState.ts
+++ b/next/store/userState.ts
@@ -3,12 +3,15 @@ import { destroyCookie, parseCookies, setCookie } from 'nookies';
 import { useEffect } from 'react';
 import { atom, useRecoilState } from 'recoil';
 import { authApi } from '~/lib/api';
+import { SCOPE_TO_LABEL } from '~/lib/api/auth';
 
-export type Scope = 'user' | 'admin';
+type Scope = keyof typeof SCOPE_TO_LABEL;
 
 export type User = {
   username: string;
   scopes: Scope[];
+  scopeIndex: number;
+  isAdminMode: boolean;
 };
 
 type Payload = {
@@ -23,11 +26,14 @@ export const userState = atom<UserState>({
   default: undefined,
 });
 
-const getUserFromToken = (token: string) => {
+const getUserFromToken = (token: string): User => {
   const pyaload: Payload = JSON.parse(atob(token.split('.')[1]));
+  const adminIndex = pyaload.scopes.findIndex((s) => s === 'admin');
   return {
     username: pyaload.sub,
     scopes: pyaload.scopes,
+    scopeIndex: adminIndex > -1 ? adminIndex : 0,
+    isAdminMode: adminIndex > -1,
   };
 };
 
@@ -79,5 +85,17 @@ export const useAuth = () => {
     router.push('/login');
   };
 
-  return { user, login, logout };
+  const changeScope = (scopeIndex: number) => {
+    if (!user) {
+      console.log('User not logged in');
+      return;
+    }
+    if (!user.scopes[scopeIndex]) {
+      console.log('Invalid scope index');
+      return;
+    }
+    setUser({ ...user, scopeIndex: scopeIndex, isAdminMode: user.scopes[scopeIndex] === 'admin' });
+  };
+
+  return { user, login, logout, changeScope };
 };

--- a/next/store/userState.ts
+++ b/next/store/userState.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { destroyCookie, parseCookies, setCookie } from 'nookies';
+import { parseCookies, setCookie } from 'nookies';
 import { useEffect } from 'react';
 import { atom, useRecoilState } from 'recoil';
 import { authApi } from '~/lib/api';
@@ -39,15 +39,15 @@ const getUserFromToken = (token: string): User => {
 
 export const useGetUser = (): UserState => {
   const [user, setUser] = useRecoilState(userState);
+  const { token } = parseCookies();
 
   useEffect(() => {
-    const { token } = parseCookies();
     if (!token) {
       setUser(null);
       return;
     }
     setUser(getUserFromToken(token));
-  }, [setUser]);
+  }, [token, setUser]);
 
   return user;
 };
@@ -80,9 +80,7 @@ export const useAuth = () => {
   };
 
   const logout = async () => {
-    setUser(null);
-    destroyCookie(null, 'token');
-    router.push('/login');
+    router.push('/logout');
   };
 
   const changeScope = (scopeIndex: number) => {

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -7167,6 +7167,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dayjs@npm:^1.11.7":
+  version: 1.11.7
+  resolution: "dayjs@npm:1.11.7"
+  checksum: 5003a7c1dd9ed51385beb658231c3548700b82d3548c0cfbe549d85f2d08e90e972510282b7506941452c58d32136d6362f009c77ca55381a09c704e9f177ebb
+  languageName: node
+  linkType: hard
+
 "debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.3.3, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
@@ -16339,6 +16346,7 @@ __metadata:
     "@types/react-dom": 18.0.6
     ajv: ^8.11.2
     babel-loader: ^8.3.0
+    dayjs: ^1.11.7
     eslint: 8.24.0
     eslint-config-next: 12.3.1
     eslint-plugin-storybook: ^0.6.11


### PR DESCRIPTION
# 概要
タスク一覧ページを作成した。
その他いくつかのコンポーネントを修正した。

# 変更点
* Hygenによるページの自動生成に対応
* タスク一覧ページの作成
* ユーザのスコープ変更に対応
* ログアウトページの作成

# バグ修正
* ユーザAをログアウトし、リロードを挟まずにユーザBでログインした時に、一瞬だけユーザAの情報が表示されていた
  * APIのキャッシュキーにユーザ名を含めることで修正
* 正しくログアウト処理されない問題を修正