### PR TITLE
Update storages and images pages

### DIFF
--- a/next/components/dialogs/AddStoragePoolDialog/index.tsx
+++ b/next/components/dialogs/AddStoragePoolDialog/index.tsx
@@ -1,9 +1,11 @@
 import { JTDDataType } from 'ajv/dist/core';
-import { FC, useCallback, useEffect } from 'react';
+import { FC, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { useSWRConfig } from 'swr';
 import { JtdForm } from '~/components/JtdForm';
 import { storagesApi } from '~/lib/api';
 import { generateProperty } from '~/lib/jtd';
+import { useNotistack } from '~/lib/utils/notistack';
 import { useChoicesFetchers } from '~/store/formState';
 import { BaseDialog } from '../BaseDialog';
 
@@ -24,6 +26,8 @@ export const AddStoragePoolDialog: FC<Props> = ({ open, onClose }) => {
     handleSubmit,
     formState: { isDirty, isValid, isSubmitting },
   } = formMethods;
+  const { enqueueNotistack } = useNotistack();
+  const { mutate } = useSWRConfig();
 
   useEffect(() => {
     if (!open) {
@@ -42,9 +46,18 @@ export const AddStoragePoolDialog: FC<Props> = ({ open, onClose }) => {
     );
   }, [open, reset, resetFetchers, setFetcher]);
 
-  const handleAddStoragePool = useCallback((data: FormData) => {
-    console.log('handleAddStoragePool', data);
-  }, []);
+  const handleAddStoragePool = (data: FormData) => {
+    return storagesApi
+      .postApiStoragesPoolsApiStoragesPoolsPost(data)
+      .then(() => {
+        enqueueNotistack('Storage pool added.', { variant: 'success' });
+        mutate('storagesApi.getApiStoragesPoolsApiStoragesPoolsGet');
+        onClose();
+      })
+      .catch(() => {
+        enqueueNotistack('Failed to add storage pool.', { variant: 'error' });
+      });
+  };
 
   return (
     <BaseDialog

--- a/next/components/layouts/DefaultLayout.tsx
+++ b/next/components/layouts/DefaultLayout.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Toolbar, useTheme } from '@mui/material';
+import { Box, Container, Toolbar, useMediaQuery, useTheme } from '@mui/material';
 import { FC, PropsWithChildren } from 'react';
 import { closedMixin, openedMixin } from '~/lib/utils/drawer';
 import { useDrawer } from '~/store/drawerState';
@@ -12,6 +12,7 @@ type Props = PropsWithChildren<{
 export const DefaultLayout: FC<Props> = ({ children, isLoading }) => {
   const { rightDrawer, rightDrawerOptions } = useDrawer();
   const theme = useTheme();
+  const isMediumScreen = useMediaQuery(theme.breakpoints.down('md'));
 
   return (
     <Box display="flex">
@@ -25,9 +26,10 @@ export const DefaultLayout: FC<Props> = ({ children, isLoading }) => {
           flexDirection: 'column',
           height: 'calc(100vh - 16px)',
           marginLeft: rightDrawerOptions.enable ? 0 : undefined,
-          ...(rightDrawer
-            ? openedMixin(theme, `calc(100% - ${rightDrawerOptions.openedWidth})`)
-            : rightDrawerOptions.enable && closedMixin(theme, `calc(100% - ${rightDrawerOptions.closedWidth})`)),
+          ...(!isMediumScreen &&
+            (rightDrawer
+              ? openedMixin(theme, `calc(100% - ${rightDrawerOptions.openedWidth})`)
+              : rightDrawerOptions.enable && closedMixin(theme, `calc(100% - ${rightDrawerOptions.closedWidth})`))),
         }}
       >
         <Toolbar />

--- a/next/components/layouts/DefaultLayout.tsx
+++ b/next/components/layouts/DefaultLayout.tsx
@@ -1,5 +1,7 @@
-import { Box, Container, Toolbar } from '@mui/material';
+import { Box, Container, Toolbar, useTheme } from '@mui/material';
 import { FC, PropsWithChildren } from 'react';
+import { closedMixin, openedMixin } from '~/lib/utils/drawer';
+import { useDrawer } from '~/store/drawerState';
 import { LoadingBox } from '../utils/LoadingBox';
 import { DefaultHeader } from './DefaultHeader';
 
@@ -8,6 +10,9 @@ type Props = PropsWithChildren<{
 }>;
 
 export const DefaultLayout: FC<Props> = ({ children, isLoading }) => {
+  const { rightDrawer, rightDrawerOptions } = useDrawer();
+  const theme = useTheme();
+
   return (
     <Box display="flex">
       <DefaultHeader />
@@ -15,7 +20,15 @@ export const DefaultLayout: FC<Props> = ({ children, isLoading }) => {
       <Container
         component="main"
         maxWidth="xl"
-        sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 16px)' }}
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: 'calc(100vh - 16px)',
+          marginLeft: rightDrawerOptions.enable ? 0 : undefined,
+          ...(rightDrawer
+            ? openedMixin(theme, `calc(100% - ${rightDrawerOptions.openedWidth})`)
+            : rightDrawerOptions.enable && closedMixin(theme, `calc(100% - ${rightDrawerOptions.closedWidth})`)),
+        }}
       >
         <Toolbar />
         {isLoading ? (

--- a/next/components/layouts/NavigationDrawer/SubNavigationDrawer/index.tsx
+++ b/next/components/layouts/NavigationDrawer/SubNavigationDrawer/index.tsx
@@ -1,31 +1,16 @@
-import { Box, CSSObject, Divider, Drawer, IconButton, List, Theme, Toolbar, Typography, useTheme } from '@mui/material';
+import { Box, Divider, Drawer, IconButton, List, Toolbar, Typography, useTheme } from '@mui/material';
 import { PageFirst } from 'mdi-material-ui';
 import { useRouter } from 'next/router';
 import { FC, memo, useMemo, useState } from 'react';
+import { closedMixin, opendMixin } from '~/lib/utils/drawer';
 import { useDrawer } from '~/store/drawerState';
-import { DRAWER_ITEMS, DRAWER_WIDTH } from '../config';
+import { DRAWER_ITEMS } from '../config';
 import { DrawerListItem } from '../DrawerListItem';
-
-const opendMixin = (theme: Theme): CSSObject => ({
-  width: DRAWER_WIDTH,
-  transition: theme.transitions.create('width', {
-    easing: theme.transitions.easing.easeOut,
-    duration: theme.transitions.duration.enteringScreen,
-  }),
-});
-
-const closedMixin = (theme: Theme): CSSObject => ({
-  width: `calc(${theme.spacing(9)} + 1px)`,
-  transition: theme.transitions.create('width', {
-    easing: theme.transitions.easing.sharp,
-    duration: theme.transitions.duration.leavingScreen,
-  }),
-});
 
 export const SubNavigationDrawer: FC = memo(function NotMemoSubNavigationDrawer() {
   const theme = useTheme();
   const router = useRouter();
-  const { drawer, closeDrawer, toggleDrawer } = useDrawer();
+  const { leftDrawer, setLeftDrawer, toggleLeftDrawer } = useDrawer();
   const [open, setOpen] = useState(false);
   const [groupItem, drawerItems] = useMemo(() => {
     const group = router.pathname.split('/')[1];
@@ -44,13 +29,13 @@ export const SubNavigationDrawer: FC = memo(function NotMemoSubNavigationDrawer(
 
   return drawerItems.length ? (
     <Drawer
-      open={drawer || open}
-      onClose={closeDrawer}
+      open={leftDrawer || open}
+      onClose={() => setLeftDrawer(false)}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
       variant="permanent"
       sx={
-        drawer || open
+        leftDrawer || open
           ? {
               ...opendMixin(theme),
               '& .MuiDrawer-paper': opendMixin(theme),
@@ -78,7 +63,7 @@ export const SubNavigationDrawer: FC = memo(function NotMemoSubNavigationDrawer(
         ))}
       </List>
       <IconButton
-        onClick={toggleDrawer}
+        onClick={toggleLeftDrawer}
         sx={{
           position: 'absolute',
           bottom: theme.spacing(2),
@@ -87,7 +72,7 @@ export const SubNavigationDrawer: FC = memo(function NotMemoSubNavigationDrawer(
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen,
           }),
-          transform: drawer ? 'rotate(0deg)' : 'rotate(180deg)',
+          transform: leftDrawer ? 'rotate(0deg)' : 'rotate(180deg)',
         }}
       >
         <PageFirst />

--- a/next/components/layouts/NavigationDrawer/SubNavigationDrawer/index.tsx
+++ b/next/components/layouts/NavigationDrawer/SubNavigationDrawer/index.tsx
@@ -2,7 +2,7 @@ import { Box, Divider, Drawer, IconButton, List, Toolbar, Typography, useTheme }
 import { PageFirst } from 'mdi-material-ui';
 import { useRouter } from 'next/router';
 import { FC, memo, useMemo, useState } from 'react';
-import { closedMixin, opendMixin } from '~/lib/utils/drawer';
+import { closedMixin, openedMixin } from '~/lib/utils/drawer';
 import { useDrawer } from '~/store/drawerState';
 import { DRAWER_ITEMS } from '../config';
 import { DrawerListItem } from '../DrawerListItem';
@@ -37,8 +37,8 @@ export const SubNavigationDrawer: FC = memo(function NotMemoSubNavigationDrawer(
       sx={
         leftDrawer || open
           ? {
-              ...opendMixin(theme),
-              '& .MuiDrawer-paper': opendMixin(theme),
+              ...openedMixin(theme),
+              '& .MuiDrawer-paper': openedMixin(theme),
             }
           : {
               ...closedMixin(theme),

--- a/next/components/layouts/NavigationDrawer/config.tsx
+++ b/next/components/layouts/NavigationDrawer/config.tsx
@@ -18,8 +18,6 @@ export type DrawerItem = {
   children?: DrawerItem[];
 };
 
-export const DRAWER_WIDTH = 250;
-
 export const DRAWER_ITEMS: DrawerItem[] = [
   {
     title: 'Dashboard',

--- a/next/components/layouts/NavigationDrawer/index.tsx
+++ b/next/components/layouts/NavigationDrawer/index.tsx
@@ -1,6 +1,7 @@
 import { Drawer, List, Toolbar, useTheme } from '@mui/material';
 import { FC, memo } from 'react';
-import { DRAWER_ITEMS, DRAWER_WIDTH } from './config';
+import { DRAWER_WIDTH } from '~/lib/utils/drawer';
+import { DRAWER_ITEMS } from './config';
 import { DrawerListItem } from './DrawerListItem';
 
 type Props = {

--- a/next/components/tables/ImagesTable/index.tsx
+++ b/next/components/tables/ImagesTable/index.tsx
@@ -1,10 +1,14 @@
 import { Box } from '@mui/material';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
-import { FC } from 'react';
+import { FC, useMemo, useState } from 'react';
 import { useNotistack } from '~/lib/utils/notistack';
-import { imagesApi } from '~/lib/api';
+import { imagesApi, storagesApi } from '~/lib/api';
 import useSWR from 'swr';
 import { FilterSettingsDrawer } from '~/components/utils/FilterSettingsDrawer';
+import { JTDDataType } from 'ajv/dist/core';
+import { generateProperty } from '~/lib/jtd';
+
+type Filters = JTDDataType<typeof filtersJtd>;
 
 export const ImagesTable: FC = () => {
   const { enqueueNotistack } = useNotistack();
@@ -12,6 +16,35 @@ export const ImagesTable: FC = () => {
     'imagesApi.getApiImagesApiImagesGet',
     () => imagesApi.getApiImagesApiImagesGet().then((res) => res.data),
     { revalidateOnFocus: false }
+  );
+  const [filters, setFilters] = useState<Filters>(generateProperty(filtersJtd));
+
+  const handleFiltersChange = (newFilters: Filters) => {
+    console.log(newFilters);
+    setFilters(newFilters);
+  };
+
+  const choicesFetchers = useMemo(
+    () => ({
+      pools: async () => {
+        const results = await Promise.all([
+          storagesApi.getApiStoragesApiStoragesGet().then((res) =>
+            res.data.map((storage) => ({
+              label: storage.name,
+              value: storage.uuid,
+            }))
+          ),
+          storagesApi.getApiStoragesPoolsApiStoragesPoolsGet().then((res) =>
+            res.data.map((storage) => ({
+              label: storage.name,
+              value: storage.id,
+            }))
+          ),
+        ]);
+        return results.flat();
+      },
+    }),
+    []
   );
 
   if (error) {
@@ -93,7 +126,45 @@ export const ImagesTable: FC = () => {
         }}
       />
 
-      <FilterSettingsDrawer />
+      <FilterSettingsDrawer filtersJtd={filtersJtd} choicesFetchers={choicesFetchers} onSubmit={handleFiltersChange} />
     </Box>
   );
 };
+
+const filtersJtd = {
+  properties: {
+    name: {
+      metadata: {
+        name: 'Name',
+        default: '',
+        required: false,
+      },
+      type: 'string',
+    },
+    nodeName: {
+      metadata: {
+        name: 'Node Name',
+        default: '',
+        required: false,
+      },
+      type: 'string',
+    },
+    poolUuid: {
+      metadata: {
+        name: 'Pool',
+        default: '',
+        required: false,
+        choices: 'pools',
+      },
+      type: 'string',
+    },
+    rool: {
+      metadata: {
+        name: 'Rool',
+        default: '',
+        required: false,
+      },
+      type: 'string',
+    },
+  },
+} as const;

--- a/next/components/tables/ImagesTable/index.tsx
+++ b/next/components/tables/ImagesTable/index.tsx
@@ -28,7 +28,13 @@ export const ImagesTable: FC = () => {
         loading={!data || isValidating}
         error={!!error || undefined}
         columns={[
-          { headerName: 'Name', field: 'name', disableColumnMenu: true, flex: 3, minWidth: 500 },
+          {
+            headerName: 'Name',
+            field: 'name',
+            disableColumnMenu: true,
+            flex: 3,
+            minWidth: 500,
+          },
           {
             headerName: 'Node',
             field: 'storage.node.name',

--- a/next/components/tables/ImagesTable/index.tsx
+++ b/next/components/tables/ImagesTable/index.tsx
@@ -4,6 +4,7 @@ import { FC } from 'react';
 import { useNotistack } from '~/lib/utils/notistack';
 import { imagesApi } from '~/lib/api';
 import useSWR from 'swr';
+import { FilterSettingsDrawer } from '~/components/utils/FilterSettingsDrawer';
 
 export const ImagesTable: FC = () => {
   const { enqueueNotistack } = useNotistack();
@@ -91,6 +92,8 @@ export const ImagesTable: FC = () => {
           },
         }}
       />
+
+      <FilterSettingsDrawer />
     </Box>
   );
 };

--- a/next/components/tables/StoragesTable/index.tsx
+++ b/next/components/tables/StoragesTable/index.tsx
@@ -5,6 +5,7 @@ import { useNotistack } from '~/lib/utils/notistack';
 import { storagesApi } from '~/lib/api';
 import useSWR from 'swr';
 import { CheckboxBlankOutline, CheckboxOutline } from 'mdi-material-ui';
+import { NextLink } from '~/components/utils/NextLink';
 
 export const StoragesTable: FC = () => {
   const { enqueueNotistack } = useNotistack();
@@ -37,6 +38,7 @@ export const StoragesTable: FC = () => {
             disableColumnMenu: true,
             flex: 2,
             minWidth: 290,
+            renderCell: (params) => <NextLink pathname={`/storages/${params.value}`}>{params.value}</NextLink>,
           },
           {
             headerName: 'Capacity',

--- a/next/components/utils/FilterSettingsDrawer/index.tsx
+++ b/next/components/utils/FilterSettingsDrawer/index.tsx
@@ -1,5 +1,5 @@
 import { LoadingButton } from '@mui/lab';
-import { Box, Divider, Drawer, IconButton, Toolbar, Typography, useTheme } from '@mui/material';
+import { Box, Divider, Drawer, IconButton, Toolbar, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { JTDDataType } from 'ajv/dist/core';
 import { Schema } from 'jtd';
 import { FilterSettings } from 'mdi-material-ui';
@@ -35,6 +35,7 @@ export const FilterSettingsDrawer: FilterSettingsDrawerComponent = ({
 }) => {
   const { rightDrawer, setRightDrawer, toggleRightDrawer, setRightDrawerOptions, resetRightDrawer } = useDrawer();
   const theme = useTheme();
+  const isMediumScreen = useMediaQuery(theme.breakpoints.down('md'));
   const formMethods = useForm({
     defaultValues: generateProperty(filtersJtd as JtdSchema),
   });
@@ -66,20 +67,17 @@ export const FilterSettingsDrawer: FilterSettingsDrawerComponent = ({
     <Drawer
       open={rightDrawer}
       onClose={() => setRightDrawer(false)}
-      variant="permanent"
+      variant={isMediumScreen ? 'temporary' : 'permanent'}
       anchor="right"
       sx={
         rightDrawer
           ? {
               ...openedMixin(theme),
-              '& .MuiDrawer-paper': openedMixin(theme, DRAWER_WIDTH),
+              '& .MuiDrawer-paper': !isMediumScreen ? openedMixin(theme, DRAWER_WIDTH) : undefined,
             }
           : {
               ...closedMixin(theme),
-              '& .MuiDrawer-paper': closedMixin(theme),
-              '& span': {
-                opacity: 0,
-              },
+              '& .MuiDrawer-paper': !isMediumScreen ? closedMixin(theme) : undefined,
             }
       }
     >
@@ -100,18 +98,20 @@ export const FilterSettingsDrawer: FilterSettingsDrawerComponent = ({
         </IconButton>
       </Box>
       <Divider />
-      <FormProvider {...formMethods}>
-        <JtdForm rootJtd={filtersJtd as JtdSchema} isEditing={true} />
-      </FormProvider>
-      <LoadingButton
-        onClick={handleSubmit(onSubmit)}
-        variant="contained"
-        disableElevation
-        loading={submitLoading}
-        sx={{ mx: 2 }}
-      >
-        Search
-      </LoadingButton>
+      <Box className="FilterSettingsDrawer-body" display="grid" sx={!rightDrawer ? { opacity: 0 } : undefined}>
+        <FormProvider {...formMethods}>
+          <JtdForm rootJtd={filtersJtd as JtdSchema} isEditing={true} />
+        </FormProvider>
+        <LoadingButton
+          onClick={handleSubmit(onSubmit)}
+          variant="contained"
+          disableElevation
+          loading={submitLoading}
+          sx={{ mx: 2 }}
+        >
+          Search
+        </LoadingButton>
+      </Box>
     </Drawer>
   );
 };

--- a/next/components/utils/FilterSettingsDrawer/index.tsx
+++ b/next/components/utils/FilterSettingsDrawer/index.tsx
@@ -1,0 +1,66 @@
+import { Box, Divider, Drawer, IconButton, Toolbar, Typography, useTheme } from '@mui/material';
+import { FilterSettings } from 'mdi-material-ui';
+import { FC, useEffect } from 'react';
+import { closedMixin, openedMixin } from '~/lib/utils/drawer';
+import { useDrawer } from '~/store/drawerState';
+
+const DRAWER_WIDTH = 350;
+
+export const FilterSettingsDrawer: FC = () => {
+  const { rightDrawer, setRightDrawer, toggleRightDrawer, setRightDrawerOptions, resetRightDrawer } = useDrawer();
+  const theme = useTheme();
+
+  useEffect(() => {
+    setRightDrawerOptions({
+      enable: true,
+      openedWidth: `${DRAWER_WIDTH}px`,
+      closedWidth: `calc(${theme.spacing(9)} + 1px)`,
+    });
+    console.log('setRightDrawerOptions');
+    return () => {
+      console.log('resetRightDrawer');
+      resetRightDrawer();
+    };
+  }, [setRightDrawerOptions, resetRightDrawer, theme]);
+
+  return (
+    <Drawer
+      open={rightDrawer}
+      onClose={() => setRightDrawer(false)}
+      variant="permanent"
+      anchor="right"
+      sx={
+        rightDrawer
+          ? {
+              ...openedMixin(theme),
+              '& .MuiDrawer-paper': openedMixin(theme, DRAWER_WIDTH),
+            }
+          : {
+              ...closedMixin(theme),
+              '& .MuiDrawer-paper': closedMixin(theme),
+              '& span': {
+                opacity: 0,
+              },
+            }
+      }
+    >
+      <Toolbar />
+      <Box display="flex" alignItems="center" sx={{ px: 2, py: 2 }}>
+        <Typography
+          variant="h6"
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          Filter Settings
+        </Typography>
+        <IconButton onClick={toggleRightDrawer} sx={{ ml: 'auto' }}>
+          <FilterSettings />
+        </IconButton>
+      </Box>
+      <Divider />
+    </Drawer>
+  );
+};

--- a/next/components/utils/NextLink/index.stories.tsx
+++ b/next/components/utils/NextLink/index.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+import { NextLink } from '.';
+
+export default {
+  title: 'Utils/NextLink',
+  component: NextLink,
+} as ComponentMeta<typeof NextLink>;
+
+export const Default: ComponentStoryObj<typeof NextLink> = {
+  args: {
+    pathname: '/test',
+    children: 'test',
+  },
+};
+
+export const WithoutUnderline: ComponentStoryObj<typeof NextLink> = {
+  args: {
+    pathname: '/test',
+    underline: 'none',
+    children: 'test',
+  },
+};
+
+export const WithoutColor: ComponentStoryObj<typeof NextLink> = {
+  args: {
+    pathname: '/test',
+    color: 'inherit',
+    children: 'test',
+  },
+};

--- a/next/components/utils/NextLink/index.tsx
+++ b/next/components/utils/NextLink/index.tsx
@@ -1,0 +1,19 @@
+import { Link, TypographyProps } from '@mui/material';
+import Nextlink from 'next/link';
+import { FC, PropsWithChildren } from 'react';
+
+type Props = PropsWithChildren<{
+  pathname: string;
+  underline?: 'none' | 'hover' | 'always';
+  color?: TypographyProps['color'];
+}>;
+
+export const NextLink: FC<Props> = ({ pathname, underline, color, children }) => {
+  return (
+    <Nextlink href={{ pathname }} passHref>
+      <Link underline={underline} color={color}>
+        {children}
+      </Link>
+    </Nextlink>
+  );
+};

--- a/next/lib/utils/drawer.ts
+++ b/next/lib/utils/drawer.ts
@@ -2,7 +2,7 @@ import { CSSObject, Theme } from '@mui/material';
 
 export const DRAWER_WIDTH = 250;
 
-export const opendMixin = (theme: Theme, width: number = DRAWER_WIDTH): CSSObject => ({
+export const openedMixin = (theme: Theme, width: number | string = DRAWER_WIDTH): CSSObject => ({
   width,
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.easeOut,
@@ -10,8 +10,8 @@ export const opendMixin = (theme: Theme, width: number = DRAWER_WIDTH): CSSObjec
   }),
 });
 
-export const closedMixin = (theme: Theme): CSSObject => ({
-  width: `calc(${theme.spacing(9)} + 1px)`,
+export const closedMixin = (theme: Theme, width: number | string = theme.spacing(9)): CSSObject => ({
+  width: `calc(${width} + 1px)`,
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,

--- a/next/lib/utils/drawer.ts
+++ b/next/lib/utils/drawer.ts
@@ -1,0 +1,19 @@
+import { CSSObject, Theme } from '@mui/material';
+
+export const DRAWER_WIDTH = 250;
+
+export const opendMixin = (theme: Theme, width: number = DRAWER_WIDTH): CSSObject => ({
+  width,
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.easeOut,
+    duration: theme.transitions.duration.enteringScreen,
+  }),
+});
+
+export const closedMixin = (theme: Theme): CSSObject => ({
+  width: `calc(${theme.spacing(9)} + 1px)`,
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+});

--- a/next/pages/images.tsx
+++ b/next/pages/images.tsx
@@ -1,13 +1,19 @@
-import { Grid, Typography } from '@mui/material';
+import { Grid, IconButton, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { FilterSettings } from 'mdi-material-ui';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { DefaultLayout } from '~/components/layouts/DefaultLayout';
 import { ImagesTable } from '~/components/tables/ImagesTable';
 import { makeRequireLoginProps } from '~/lib/utils/makeGetServerSideProps';
+import { useDrawer } from '~/store/drawerState';
 
 export const getServerSideProps = makeRequireLoginProps();
 
 const Page: NextPage = () => {
+  const theme = useTheme();
+  const isMediumScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const { toggleRightDrawer } = useDrawer();
+
   return (
     <DefaultLayout>
       <Head>
@@ -18,6 +24,13 @@ const Page: NextPage = () => {
         <Grid item>
           <Typography variant="h4">Images</Typography>
         </Grid>
+        {isMediumScreen && (
+          <Grid item sx={{ ml: 'auto' }}>
+            <IconButton onClick={toggleRightDrawer}>
+              <FilterSettings />
+            </IconButton>
+          </Grid>
+        )}
       </Grid>
 
       <ImagesTable />

--- a/next/pages/storages/[id].tsx
+++ b/next/pages/storages/[id].tsx
@@ -1,0 +1,102 @@
+import { Button, Grid, Typography } from '@mui/material';
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import useSWR from 'swr';
+import { DefaultLayout } from '~/components/layouts/DefaultLayout';
+import { storagesApi } from '~/lib/api';
+import { makeRequireLoginProps } from '~/lib/utils/makeGetServerSideProps';
+import { useConfirmDialog } from '~/store/confirmDialogState';
+import Error404Page from '../404';
+import ErrorPage from '../error';
+
+type Props = {
+  id: string;
+};
+
+export const getServerSideProps = makeRequireLoginProps(async ({ params }) => {
+  const id = params?.id;
+  if (typeof id !== 'string') {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      id,
+    },
+  };
+});
+
+const Page: NextPage<Props> = ({ id }) => {
+  const { data, error, isValidating } = useSWR(
+    ['networkApi.getApiNetworksUuidApiNetworksUuidGet'],
+    () =>
+      storagesApi
+        .getApiStoragesApiStoragesGet()
+        .then((res) => res.data.find((storage) => storage.uuid === id))
+        .catch((err) => {
+          if (err.response.status === 404) {
+            return null;
+          }
+          throw err;
+        }),
+    {
+      revalidateOnFocus: false,
+      shouldRetryOnError: false,
+    }
+  );
+  const { openConfirmDialog } = useConfirmDialog();
+
+  if (isValidating) {
+    return <DefaultLayout isLoading />;
+  }
+
+  if (error) {
+    return <ErrorPage message={error.message} />;
+  }
+
+  if (!data) {
+    return <Error404Page />;
+  }
+
+  const deleteStorage = async () => {
+    const confirmed = await openConfirmDialog({
+      title: 'Delete Storage',
+      description: 'Are you sure you want to delete this storage?',
+      submitText: 'Delete',
+      color: 'error',
+    });
+    if (!confirmed) {
+      return;
+    }
+
+    console.log('delete storage');
+  };
+
+  return (
+    <DefaultLayout>
+      <Head>
+        <title>Virty - {data.name}</title>
+      </Head>
+
+      <Grid container alignItems="baseline" spacing={2} sx={{ mt: 0, mb: 2 }}>
+        <Grid item>
+          <Typography variant="h6">{data.name}</Typography>
+        </Grid>
+        <Grid item>
+          <Typography variant="subtitle1">{data.uuid}</Typography>
+        </Grid>
+        <Grid item>
+          <Button variant="contained" color="error" disableElevation size="small" onClick={deleteStorage}>
+            Delete
+          </Button>
+        </Grid>
+      </Grid>
+
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </DefaultLayout>
+  );
+};
+
+export default Page;

--- a/next/pages/storages/index.tsx
+++ b/next/pages/storages/index.tsx
@@ -1,15 +1,26 @@
-import { Grid, Typography } from '@mui/material';
+import { Button, Grid, Typography } from '@mui/material';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { OpenDialogButton } from '~/components/buttons/OpenDialogButton';
 import { AddStorageDialog } from '~/components/dialogs/AddStorageDialog';
 import { DefaultLayout } from '~/components/layouts/DefaultLayout';
 import { StoragesTable } from '~/components/tables/StoragesTable';
+import { tasksImagesApi } from '~/lib/api';
 import { makeRequireLoginProps } from '~/lib/utils/makeGetServerSideProps';
+import { useNotistack } from '~/lib/utils/notistack';
 
 export const getServerSideProps = makeRequireLoginProps();
 
 const Page: NextPage = () => {
+  const { enqueueNotistack } = useNotistack();
+
+  const reloadStorages = () => {
+    tasksImagesApi
+      .putApiImagesApiTasksImagesPut()
+      .then(() => enqueueNotistack('Storage list is being updated.', { variant: 'success' }))
+      .catch(() => enqueueNotistack('Failed to update storage list.', { variant: 'error' }));
+  };
+
   return (
     <DefaultLayout>
       <Head>
@@ -19,6 +30,11 @@ const Page: NextPage = () => {
       <Grid container alignItems="center" spacing={2} sx={{ mt: 0, mb: 1 }}>
         <Grid item>
           <Typography variant="h4">Storages</Typography>
+        </Grid>
+        <Grid item>
+          <Button variant="contained" color="primary" onClick={reloadStorages}>
+            Reload
+          </Button>
         </Grid>
         <Grid item>
           <OpenDialogButton label="Add" DialogComponent={AddStorageDialog} buttonProps={{ variant: 'contained' }} />

--- a/next/store/drawerState.ts
+++ b/next/store/drawerState.ts
@@ -1,4 +1,5 @@
-import { useCallback } from 'react';
+import { useMediaQuery, useTheme } from '@mui/material';
+import { useCallback, useEffect } from 'react';
 import { atom, useRecoilState } from 'recoil';
 
 export const leftDrawerState = atom<boolean>({
@@ -25,9 +26,19 @@ export const rightDrawerOptionsState = atom<DrawerOptions>({
 });
 
 export const useDrawer = () => {
+  const theme = useTheme();
+  const isMediumScreen = useMediaQuery(theme.breakpoints.down('md'));
   const [leftDrawer, setLeftDrawer] = useRecoilState(leftDrawerState);
   const [rightDrawer, setRightDrawer] = useRecoilState(rightDrawerState);
   const [rightDrawerOptions, _setRightDrawerOptions] = useRecoilState(rightDrawerOptionsState);
+
+  useEffect(() => {
+    if (isMediumScreen) {
+      setRightDrawer(false);
+    } else {
+      setRightDrawer(true);
+    }
+  }, [isMediumScreen, setRightDrawer]);
 
   const toggleLeftDrawer = useCallback(() => {
     setLeftDrawer((prev) => !prev);

--- a/next/store/drawerState.ts
+++ b/next/store/drawerState.ts
@@ -1,16 +1,68 @@
+import { useCallback } from 'react';
 import { atom, useRecoilState } from 'recoil';
 
-export const drawerState = atom<boolean>({
-  key: 'drawer',
+export const leftDrawerState = atom<boolean>({
+  key: 'leftDrawer',
   default: true,
 });
 
+export const rightDrawerState = atom<boolean>({
+  key: 'rightDrawer',
+  default: true,
+});
+
+type DrawerOptions = {
+  enable?: boolean;
+  openedWidth?: string;
+  closedWidth?: string;
+};
+
+export const rightDrawerOptionsState = atom<DrawerOptions>({
+  key: 'rightDrawerOptions',
+  default: {
+    enable: false,
+  },
+});
+
 export const useDrawer = () => {
-  const [drawer, setDrawer] = useRecoilState(drawerState);
+  const [leftDrawer, setLeftDrawer] = useRecoilState(leftDrawerState);
+  const [rightDrawer, setRightDrawer] = useRecoilState(rightDrawerState);
+  const [rightDrawerOptions, _setRightDrawerOptions] = useRecoilState(rightDrawerOptionsState);
 
-  const openDrawer = () => setDrawer(true);
-  const closeDrawer = () => setDrawer(false);
-  const toggleDrawer = () => setDrawer(!drawer);
+  const toggleLeftDrawer = useCallback(() => {
+    setLeftDrawer((prev) => !prev);
+  }, [setLeftDrawer]);
 
-  return { drawer, openDrawer, closeDrawer, toggleDrawer };
+  const toggleRightDrawer = useCallback(() => {
+    setRightDrawer((prev) => !prev);
+  }, [setRightDrawer]);
+
+  const setRightDrawerOptions = useCallback(
+    (options: DrawerOptions) => {
+      _setRightDrawerOptions((prev) => ({
+        ...prev,
+        ...options,
+      }));
+    },
+    [_setRightDrawerOptions]
+  );
+
+  const resetRightDrawer = useCallback(() => {
+    setRightDrawer(true);
+    _setRightDrawerOptions({
+      enable: false,
+    });
+  }, [setRightDrawer, _setRightDrawerOptions]);
+
+  return {
+    leftDrawer,
+    setLeftDrawer,
+    toggleLeftDrawer,
+    rightDrawer: rightDrawerOptions.enable ? rightDrawer : false,
+    setRightDrawer,
+    toggleRightDrawer,
+    rightDrawerOptions,
+    setRightDrawerOptions,
+    resetRightDrawer,
+  };
 };


### PR DESCRIPTION
# 概要
ストレージ関連ページ、イメージページに機能を追加した。
また、ストレージ詳細ページを作成した。
これはAPIがないため全てのストレージを取得してフィルタリングする実装とした。

イメージ一覧ページで詳細なフィルタリングができるようにした。

# 変更点
* ストレージのリロード機能追加
* ストレージプールの作成機能追加
* Nextを使ったルーティングのための`NextLink`コンポーネントの作成
* ストレージ詳細ページの作成
* フィルタリングに使えるドロワーメニューとして`FilterSettingsDrawer`コンポーネントを作成