### PR TITLE
Show port property when network type is openvswitch only

### DIFF
--- a/next/components/JtdForm/PropertyInput.tsx
+++ b/next/components/JtdForm/PropertyInput.tsx
@@ -26,7 +26,7 @@ import { FC, PropsWithChildren, useEffect } from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { generateProperties, generateProperty, getRelatedValue } from '~/lib/jtd';
 import { Choice, MetaData } from '~/lib/jtd/types';
-import { useChoices } from '~/store/formState';
+import { useChoices, useFormExtraData } from '~/store/formState';
 import { Close, Plus } from 'mdi-material-ui';
 import { StepperForm } from './StepperForm';
 
@@ -57,6 +57,7 @@ export const PropertyInput: FC<PropertyInputProps> = (props) => {
   const { control, getValues, setValue } = useFormContext();
   const propertyName = prefixPropertyName + propertyKey;
   const { choices, isLoading } = useChoices(propertyJtd.metadata, getValues, propertyName);
+  const { setExtraData, extraData } = useFormExtraData();
 
   useEffect(() => {
     if (typeof propertyJtd.metadata?.default === 'function' && !getValues(propertyName)) {
@@ -65,7 +66,10 @@ export const PropertyInput: FC<PropertyInputProps> = (props) => {
   }, [getValues, propertyName, propertyJtd.metadata, setValue]);
 
   if (propertyJtd.metadata?.hidden) {
-    if (propertyJtd.metadata.hidden === true || propertyJtd.metadata.hidden(getRelatedValue(getValues, propertyName))) {
+    if (
+      propertyJtd.metadata.hidden === true ||
+      propertyJtd.metadata.hidden(getRelatedValue(getValues, propertyName), extraData)
+    ) {
       return null;
     }
   }
@@ -206,7 +210,11 @@ export const PropertyInput: FC<PropertyInputProps> = (props) => {
                   labelId={propertyName}
                   inputProps={{ readOnly: !isEditing }}
                   value={value || ''}
-                  onChange={onChange}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setExtraData(choices.find((c) => c.value === v)?.extraData);
+                    onChange(v);
+                  }}
                 >
                   {!propertyRequired && (
                     <MenuItem value="">

--- a/next/components/JtdForm/index.tsx
+++ b/next/components/JtdForm/index.tsx
@@ -1,7 +1,7 @@
 import { Grid } from '@mui/material';
 import { Schema } from 'jtd';
 import { FC, useEffect } from 'react';
-import { useJtdForm } from '~/store/formState';
+import { useFormExtraData, useJtdForm } from '~/store/formState';
 import { MetaData } from '~/lib/jtd/types';
 import { PropertyInput } from './PropertyInput';
 
@@ -15,12 +15,14 @@ type Props = {
 
 export const JtdForm: FC<Props> = ({ prefixPropertyName, propertyJtd, rootJtd, isEditing, isError = false }) => {
   const { reset } = useJtdForm(rootJtd);
+  const { resetExtraData } = useFormExtraData();
 
   useEffect(
     () => () => {
       reset();
+      resetExtraData();
     },
-    [reset]
+    [reset, resetExtraData]
   );
 
   return (

--- a/next/lib/jtd/types.ts
+++ b/next/lib/jtd/types.ts
@@ -23,7 +23,7 @@ export interface MetaData {
    * If true, the property is not displayed in the dialog.
    * @default false
    */
-  hidden?: boolean | ((get: any) => boolean);
+  hidden?: boolean | ((get: any, extraData: Record<string, any>) => boolean);
   /**
    * If true, the property is required.
    * (Do not use optionalProperties because it is not possible to define the order of the forms.)
@@ -67,4 +67,5 @@ export interface MetaData {
 export interface Choice {
   label: string;
   value: string | number;
+  extraData?: any;
 }

--- a/next/store/formState.ts
+++ b/next/store/formState.ts
@@ -166,3 +166,30 @@ export const useJtdForm = (jtd: Schema) => {
 
   return { reset };
 };
+
+const formExtraDataState = atom<Record<string, any>>({
+  key: 'formExtraData',
+  default: {},
+});
+
+export const useFormExtraData = () => {
+  const [formExtraData, setFormExtraData] = useRecoilState(formExtraDataState);
+
+  const setExtraData = useCallback(
+    (extraData: any) => {
+      if (!extraData) return;
+
+      setFormExtraData((oldValue) => ({
+        ...oldValue,
+        ...extraData,
+      }));
+    },
+    [setFormExtraData]
+  );
+
+  const resetExtraData = useCallback(() => {
+    setFormExtraData({});
+  }, [setFormExtraData]);
+
+  return { setExtraData, extraData: formExtraData, resetExtraData };
+};


### PR DESCRIPTION
close https://github.com/hibiki31/virty/issues/99

ネットワークタイプが`openvswitch`の時のみportを表示するようにしました。
この機能を入れるためフォームジェネレータで`choices`を扱うときに追加データを参照できるようにしました。